### PR TITLE
Add contests module with Prisma integration and API endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ditmar/api-leetcode:${{ env.VERSION }}
+          tags: ditmar/api-leetcode:${{ env.VERSION }}-build.${{ github.run_id }},ditmar/api-leetcode:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ditmar/api-leetcode:${{ env.VERSION }}-build.${{ github.run_id }},ditmar/api-leetcode:latest
+          tags: ditmar/api-leetcode:${{ env.VERSION }}-build.${{ github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ditmar/api-leetcode:${{ env.VERSION }}-build.${{ github.run_id }}
+          tags: ditmar/api-leetcode:${{ env.VERSION }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-leetcode",
-  "version": "0.0.3",
+  "version": "0.0.3-rc.3",
   "description": "Express API with TypeScript",
   "main": "dist/index.js",
   "scripts": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,12 +20,11 @@ model User {
   password  String
   createdAt DateTime @default(now()) @map("created_at")
 
-  // Relations
-  testSessions       TestSession[]
-  submissions        Submission[]
-  refreshTokens      RefreshToken[]
-  enrollments        Enrollment[]
-  problemSubmissions ProblemSubmission[]
+  // Relaciones
+  testSessions TestSession[]
+  submissions  Submission[]
+  refreshTokens RefreshToken[]
+  enrollments  Enrollment[]
 
   @@map("users")
 }
@@ -236,6 +235,67 @@ model Enrollment {
   @@index([userId])
   @@index([courseId])
   @@map("enrollments")
+}
+
+model Problem {
+  id          String   @id @default(uuid())
+  title       String
+  description String   @db.Text
+  difficulty  String
+  createdAt   DateTime @default(now()) @map("created_at")
+
+  contestProblems ContestProblem[]
+
+  @@map("problems")
+}
+
+model Contest {
+  id            String   @id @default(uuid())
+  title         String
+  description   String   @db.Text
+  difficulty    String
+  status        String   @default("upcoming")
+  prize         String?
+  startTime     DateTime @map("start_time")
+  endTime       DateTime @map("end_time")
+  durationMins  Int      @map("duration_mins")
+  isActive      Boolean  @default(true) @map("is_active")
+  createdAt     DateTime @default(now()) @map("created_at")
+  updatedAt     DateTime @updatedAt @map("updated_at")
+
+  problems      ContestProblem[]
+  registrations ContestRegistration[]
+
+  @@index([status])
+  @@index([startTime])
+  @@map("contests")
+}
+
+model ContestProblem {
+  id        String @id @default(uuid())
+  contestId String @map("contest_id")
+  problemId String @map("problem_id")
+  order     Int    @default(0)
+  points    Int    @default(100)
+
+  contest Contest @relation(fields: [contestId], references: [id], onDelete: Cascade)
+  problem Problem @relation(fields: [problemId], references: [id], onDelete: Cascade)
+
+  @@unique([contestId, problemId])
+  @@map("contest_problems")
+}
+
+model ContestRegistration {
+  id        String   @id @default(uuid())
+  contestId String   @map("contest_id")
+  userId    String   @map("user_id")
+  joinedAt  DateTime @default(now()) @map("joined_at")
+
+  contest Contest @relation(fields: [contestId], references: [id], onDelete: Cascade)
+  user    User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([contestId, userId])
+  @@map("contest_registrations")
 }
 
 // ============================================

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,11 +20,13 @@ model User {
   password  String
   createdAt DateTime @default(now()) @map("created_at")
 
-  // Relaciones
-  testSessions TestSession[]
-  submissions  Submission[]
-  refreshTokens RefreshToken[]
-  enrollments  Enrollment[]
+  // Relations
+  testSessions       TestSession[]
+  submissions        Submission[]
+  refreshTokens      RefreshToken[]
+  enrollments        Enrollment[]
+  contestRegistrations ContestRegistration[]
+  problemSubmissions ProblemSubmission[]
 
   @@map("users")
 }
@@ -237,7 +239,10 @@ model Enrollment {
   @@map("enrollments")
 }
 
-model Problem {
+// ============================================
+// MODELO - Contest & Related (from your feature)
+// ============================================
+model ContestProblemDef {
   id          String   @id @default(uuid())
   title       String
   description String   @db.Text
@@ -246,7 +251,7 @@ model Problem {
 
   contestProblems ContestProblem[]
 
-  @@map("problems")
+  @@map("contest_problem_defs")
 }
 
 model Contest {
@@ -278,8 +283,8 @@ model ContestProblem {
   order     Int    @default(0)
   points    Int    @default(100)
 
-  contest Contest @relation(fields: [contestId], references: [id], onDelete: Cascade)
-  problem Problem @relation(fields: [problemId], references: [id], onDelete: Cascade)
+  contest Contest              @relation(fields: [contestId], references: [id], onDelete: Cascade)
+  problem ContestProblemDef    @relation(fields: [problemId], references: [id], onDelete: Cascade)
 
   @@unique([contestId, problemId])
   @@map("contest_problems")

--- a/src/contests/application/dtos/contest-response.dto.ts
+++ b/src/contests/application/dtos/contest-response.dto.ts
@@ -3,6 +3,12 @@ export interface ContestProblemResponseDTO {
   problemId: string;
   order: number;
   points: number;
+  problem?: {
+    id: string;
+    title: string;
+    description: string;
+    difficulty: string;
+  };
 }
 
 export interface ContestResponseDTO {

--- a/src/contests/application/dtos/contest-response.dto.ts
+++ b/src/contests/application/dtos/contest-response.dto.ts
@@ -1,0 +1,22 @@
+export interface ContestProblemResponseDTO {
+  id: string;
+  problemId: string;
+  order: number;
+  points: number;
+}
+
+export interface ContestResponseDTO {
+  id: string;
+  title: string;
+  description: string;
+  difficulty: string;
+  status: string;
+  startTime: string;
+  endTime: string;
+  durationMins: number;
+  prize: string | null;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+  problems?: ContestProblemResponseDTO[];
+}

--- a/src/contests/application/dtos/create-contest.dto.ts
+++ b/src/contests/application/dtos/create-contest.dto.ts
@@ -1,0 +1,9 @@
+export interface CreateContestDTO {
+  title: string;
+  description: string;
+  difficulty: 'EASY' | 'MEDIUM' | 'HARD';
+  startTime: string;
+  endTime: string;
+  durationMins: number;
+  prize?: string;
+}

--- a/src/contests/application/dtos/create-contest.dto.ts
+++ b/src/contests/application/dtos/create-contest.dto.ts
@@ -6,4 +6,5 @@ export interface CreateContestDTO {
   endTime: string;
   durationMins: number;
   prize?: string;
+  problemIds?: string[];
 }

--- a/src/contests/application/dtos/get-contests.dto.ts
+++ b/src/contests/application/dtos/get-contests.dto.ts
@@ -1,0 +1,5 @@
+export interface GetContestsDTO {
+  status?: 'upcoming' | 'active' | 'past';
+  skip?: number;
+  take?: number;
+}

--- a/src/contests/application/use-cases/create-contest.use-case.ts
+++ b/src/contests/application/use-cases/create-contest.use-case.ts
@@ -1,0 +1,39 @@
+import { Contest } from '../../domain/entities/contest.entity';
+import { ContestRepository } from '../../domain/repositories/contest.repository';
+import { CreateContestDTO } from '../dtos/create-contest.dto';
+import { v4 as uuidv4 } from 'uuid';
+
+export class CreateContestUseCase {
+  constructor(private contestRepository: ContestRepository) {}
+
+  async execute(dto: CreateContestDTO): Promise<Contest> {
+    const startTime = new Date(dto.startTime);
+    const endTime = new Date(dto.endTime);
+
+    if (endTime <= startTime) {
+      throw new Error('End time must be after start time');
+    }
+
+    if (dto.durationMins <= 0) {
+      throw new Error('Duration must be positive');
+    }
+
+    const contest = Contest.create(
+      uuidv4(),
+      dto.title,
+      dto.description,
+      dto.difficulty,
+      'upcoming',
+      startTime,
+      endTime,
+      dto.durationMins,
+      true,
+      dto.prize || null,
+      new Date(),
+      new Date(),
+      []
+    );
+
+    return this.contestRepository.create(contest);
+  }
+}

--- a/src/contests/application/use-cases/create-contest.use-case.ts
+++ b/src/contests/application/use-cases/create-contest.use-case.ts
@@ -3,6 +3,15 @@ import { ContestRepository } from '../../domain/repositories/contest.repository'
 import { CreateContestDTO } from '../dtos/create-contest.dto';
 import { v4 as uuidv4 } from 'uuid';
 
+const MAX_CONTEST_DURATION_MINS = 10080;
+
+class ContestValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ContestValidationError';
+  }
+}
+
 export class CreateContestUseCase {
   constructor(private contestRepository: ContestRepository) {}
 
@@ -11,11 +20,13 @@ export class CreateContestUseCase {
     const endTime = new Date(dto.endTime);
 
     if (endTime <= startTime) {
-      throw new Error('End time must be after start time');
+      throw new ContestValidationError('End time must be after start time');
     }
 
-    if (dto.durationMins <= 0) {
-      throw new Error('Duration must be positive');
+    if (dto.durationMins <= 0 || dto.durationMins > MAX_CONTEST_DURATION_MINS) {
+      throw new ContestValidationError(
+        'Duration must be between 1 and 10080 minutes'
+      );
     }
 
     const contest = Contest.create(

--- a/src/contests/application/use-cases/create-contest.use-case.ts
+++ b/src/contests/application/use-cases/create-contest.use-case.ts
@@ -34,6 +34,6 @@ export class CreateContestUseCase {
       []
     );
 
-    return this.contestRepository.create(contest);
+    return this.contestRepository.create(contest, dto.problemIds);
   }
 }

--- a/src/contests/application/use-cases/get-contest-by-id.use-case.ts
+++ b/src/contests/application/use-cases/get-contest-by-id.use-case.ts
@@ -1,19 +1,22 @@
 import { Contest } from '../../domain/entities/contest.entity';
 import { ContestRepository } from '../../domain/repositories/contest.repository';
+import { validate as isValidUUID } from 'uuid';
+
+class ContestValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ContestValidationError';
+  }
+}
 
 export class GetContestByIdUseCase {
   constructor(private contestRepository: ContestRepository) {}
 
   async execute(id: string): Promise<Contest | null> {
-    if (!this.isValidUUID(id)) {
-      throw new Error('Invalid contest ID format');
+    if (!isValidUUID(id)) {
+      throw new ContestValidationError('Invalid contest ID format');
     }
-    return this.contestRepository.getById(id);
-  }
 
-  private isValidUUID(uuid: string): boolean {
-    const uuidRegex =
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    return uuidRegex.test(uuid);
+    return this.contestRepository.getById(id);
   }
 }

--- a/src/contests/application/use-cases/get-contest-by-id.use-case.ts
+++ b/src/contests/application/use-cases/get-contest-by-id.use-case.ts
@@ -1,0 +1,19 @@
+import { Contest } from '../../domain/entities/contest.entity';
+import { ContestRepository } from '../../domain/repositories/contest.repository';
+
+export class GetContestByIdUseCase {
+  constructor(private contestRepository: ContestRepository) {}
+
+  async execute(id: string): Promise<Contest | null> {
+    if (!this.isValidUUID(id)) {
+      throw new Error('Invalid contest ID format');
+    }
+    return this.contestRepository.getById(id);
+  }
+
+  private isValidUUID(uuid: string): boolean {
+    const uuidRegex =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    return uuidRegex.test(uuid);
+  }
+}

--- a/src/contests/application/use-cases/get-contest-stats.use-case.ts
+++ b/src/contests/application/use-cases/get-contest-stats.use-case.ts
@@ -1,0 +1,12 @@
+import {
+  ContestRepository,
+  ContestStats,
+} from '../../domain/repositories/contest.repository';
+
+export class GetContestStatsUseCase {
+  constructor(private contestRepository: ContestRepository) {}
+
+  async execute(): Promise<ContestStats> {
+    return this.contestRepository.getStats();
+  }
+}

--- a/src/contests/application/use-cases/get-contests.use-case.ts
+++ b/src/contests/application/use-cases/get-contests.use-case.ts
@@ -1,0 +1,20 @@
+import { Contest } from '../../domain/entities/contest.entity';
+import {
+  ContestRepository,
+  GetContestsParams,
+} from '../../domain/repositories/contest.repository';
+import { GetContestsDTO } from '../dtos/get-contests.dto';
+
+export class GetContestsUseCase {
+  constructor(private contestRepository: ContestRepository) {}
+
+  async execute(params: GetContestsDTO): Promise<Contest[]> {
+    const repositoryParams: GetContestsParams = {
+      status: params.status,
+      skip: params.skip || 0,
+      take: params.take || 10,
+    };
+
+    return this.contestRepository.getAll(repositoryParams);
+  }
+}

--- a/src/contests/application/use-cases/register-for-contest.use-case.ts
+++ b/src/contests/application/use-cases/register-for-contest.use-case.ts
@@ -1,0 +1,41 @@
+import { ContestRepository } from '../../domain/repositories/contest.repository';
+import { PrismaClient } from '@prisma/client';
+
+export class RegisterForContestUseCase {
+  constructor(
+    private contestRepository: ContestRepository,
+    private prisma: PrismaClient
+  ) {}
+
+  async execute(
+    contestId: string,
+    userId: string
+  ): Promise<{ registered: boolean }> {
+    const contest = await this.contestRepository.getById(contestId);
+    if (!contest) {
+      throw new Error('Contest not found');
+    }
+
+    const existing = await this.prisma.contestRegistration.findUnique({
+      where: {
+        contestId_userId: {
+          contestId,
+          userId,
+        },
+      },
+    });
+
+    if (existing) {
+      return { registered: true };
+    }
+
+    await this.prisma.contestRegistration.create({
+      data: {
+        contestId,
+        userId,
+      },
+    });
+
+    return { registered: true };
+  }
+}

--- a/src/contests/application/use-cases/register-for-contest.use-case.ts
+++ b/src/contests/application/use-cases/register-for-contest.use-case.ts
@@ -1,6 +1,13 @@
 import { ContestRepository } from '../../domain/repositories/contest.repository';
 import { PrismaClient } from '@prisma/client';
 
+class ContestNotFoundError extends Error {
+  constructor(message = 'Contest not found') {
+    super(message);
+    this.name = 'ContestNotFoundError';
+  }
+}
+
 export class RegisterForContestUseCase {
   constructor(
     private contestRepository: ContestRepository,
@@ -13,7 +20,7 @@ export class RegisterForContestUseCase {
   ): Promise<{ registered: boolean }> {
     const contest = await this.contestRepository.getById(contestId);
     if (!contest) {
-      throw new Error('Contest not found');
+      throw new ContestNotFoundError('Contest not found');
     }
 
     const existing = await this.prisma.contestRegistration.findUnique({

--- a/src/contests/domain/entities/contest.entity.ts
+++ b/src/contests/domain/entities/contest.entity.ts
@@ -5,6 +5,12 @@ export interface ContestProblem {
   problemId: string;
   order: number;
   points: number;
+  problem?: {
+    id: string;
+    title: string;
+    description: string;
+    difficulty: string;
+  };
 }
 
 export class Contest {

--- a/src/contests/domain/entities/contest.entity.ts
+++ b/src/contests/domain/entities/contest.entity.ts
@@ -1,5 +1,14 @@
 import { ContestStatus } from '../value-objects/contest-status.vo';
 
+const MAX_CONTEST_DURATION_MINS = 10080;
+
+class ContestValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ContestValidationError';
+  }
+}
+
 export interface ContestProblem {
   id: string;
   problemId: string;
@@ -101,8 +110,10 @@ export class Contest {
       throw new Error('End time must be after start time');
     }
 
-    if (durationMins <= 0) {
-      throw new Error('Duration must be positive');
+    if (durationMins <= 0 || durationMins > MAX_CONTEST_DURATION_MINS) {
+      throw new ContestValidationError(
+        'Duration must be between 1 and 10080 minutes'
+      );
     }
 
     return new Contest(

--- a/src/contests/domain/entities/contest.entity.ts
+++ b/src/contests/domain/entities/contest.entity.ts
@@ -1,0 +1,118 @@
+import { ContestStatus } from '../value-objects/contest-status.vo';
+
+export interface ContestProblem {
+  id: string;
+  problemId: string;
+  order: number;
+  points: number;
+}
+
+export class Contest {
+  private constructor(
+    private readonly id: string,
+    private readonly title: string,
+    private readonly description: string,
+    private readonly difficulty: string,
+    private readonly status: ContestStatus,
+    private readonly startTime: Date,
+    private readonly endTime: Date,
+    private readonly durationMins: number,
+    private readonly isActive: boolean,
+    private readonly prize: string | null,
+    private readonly createdAt: Date,
+    private readonly updatedAt: Date,
+    private readonly problems: ContestProblem[] = []
+  ) {}
+
+  getId(): string {
+    return this.id;
+  }
+
+  getTitle(): string {
+    return this.title;
+  }
+
+  getDescription(): string {
+    return this.description;
+  }
+
+  getDifficulty(): string {
+    return this.difficulty;
+  }
+
+  getStatus(): ContestStatus {
+    return this.status;
+  }
+
+  getStartTime(): Date {
+    return this.startTime;
+  }
+
+  getEndTime(): Date {
+    return this.endTime;
+  }
+
+  getDurationMins(): number {
+    return this.durationMins;
+  }
+
+  isActiveContest(): boolean {
+    return this.isActive;
+  }
+
+  getPrize(): string | null {
+    return this.prize;
+  }
+
+  getCreatedAt(): Date {
+    return this.createdAt;
+  }
+
+  getUpdatedAt(): Date {
+    return this.updatedAt;
+  }
+
+  getProblems(): ContestProblem[] {
+    return this.problems;
+  }
+
+  static create(
+    id: string,
+    title: string,
+    description: string,
+    difficulty: string,
+    status: string,
+    startTime: Date,
+    endTime: Date,
+    durationMins: number,
+    isActive: boolean,
+    prize: string | null,
+    createdAt: Date,
+    updatedAt: Date,
+    problems?: ContestProblem[]
+  ): Contest {
+    if (endTime <= startTime) {
+      throw new Error('End time must be after start time');
+    }
+
+    if (durationMins <= 0) {
+      throw new Error('Duration must be positive');
+    }
+
+    return new Contest(
+      id,
+      title,
+      description,
+      difficulty,
+      ContestStatus.from(status),
+      startTime,
+      endTime,
+      durationMins,
+      isActive,
+      prize,
+      createdAt,
+      updatedAt,
+      problems || []
+    );
+  }
+}

--- a/src/contests/domain/repositories/contest.repository.ts
+++ b/src/contests/domain/repositories/contest.repository.ts
@@ -1,0 +1,21 @@
+import { Contest } from '../entities/contest.entity';
+
+export interface GetContestsParams {
+  status?: string;
+  skip?: number;
+  take?: number;
+}
+
+export interface ContestStats {
+  live: number;
+  upcoming: number;
+  past: number;
+  totalRegistrations: number;
+}
+
+export abstract class ContestRepository {
+  abstract getAll(params: GetContestsParams): Promise<Contest[]>;
+  abstract getById(id: string): Promise<Contest | null>;
+  abstract create(contest: Contest): Promise<Contest>;
+  abstract getStats(): Promise<ContestStats>;
+}

--- a/src/contests/domain/repositories/contest.repository.ts
+++ b/src/contests/domain/repositories/contest.repository.ts
@@ -16,6 +16,6 @@ export interface ContestStats {
 export abstract class ContestRepository {
   abstract getAll(params: GetContestsParams): Promise<Contest[]>;
   abstract getById(id: string): Promise<Contest | null>;
-  abstract create(contest: Contest): Promise<Contest>;
+  abstract create(contest: Contest, problemIds?: string[]): Promise<Contest>;
   abstract getStats(): Promise<ContestStats>;
 }

--- a/src/contests/domain/value-objects/contest-status.vo.ts
+++ b/src/contests/domain/value-objects/contest-status.vo.ts
@@ -1,0 +1,41 @@
+export type ContestStatusType = 'upcoming' | 'active' | 'past';
+
+export class ContestStatus {
+  constructor(private readonly value: ContestStatusType) {
+    if (!['upcoming', 'active', 'past'].includes(value)) {
+      throw new Error(`Invalid contest status: ${value}`);
+    }
+  }
+
+  getValue(): ContestStatusType {
+    return this.value;
+  }
+
+  isUpcoming(): boolean {
+    return this.value === 'upcoming';
+  }
+
+  isActive(): boolean {
+    return this.value === 'active';
+  }
+
+  isPast(): boolean {
+    return this.value === 'past';
+  }
+
+  static upcoming(): ContestStatus {
+    return new ContestStatus('upcoming');
+  }
+
+  static active(): ContestStatus {
+    return new ContestStatus('active');
+  }
+
+  static past(): ContestStatus {
+    return new ContestStatus('past');
+  }
+
+  static from(value: string): ContestStatus {
+    return new ContestStatus(value as ContestStatusType);
+  }
+}

--- a/src/contests/infrastructure/contests.router.ts
+++ b/src/contests/infrastructure/contests.router.ts
@@ -1,0 +1,41 @@
+import { Router } from 'express';
+import { ContestsController } from './controllers/contests.controller';
+import { GetContestsUseCase } from '../application/use-cases/get-contests.use-case';
+import { GetContestByIdUseCase } from '../application/use-cases/get-contest-by-id.use-case';
+import { CreateContestUseCase } from '../application/use-cases/create-contest.use-case';
+import { RegisterForContestUseCase } from '../application/use-cases/register-for-contest.use-case';
+import { GetContestStatsUseCase } from '../application/use-cases/get-contest-stats.use-case';
+import { PrismaContestRepository } from './persistence/prisma-contest.repository';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const repository = new PrismaContestRepository(prisma);
+
+const getContestsUseCase = new GetContestsUseCase(repository);
+const getContestByIdUseCase = new GetContestByIdUseCase(repository);
+const createContestUseCase = new CreateContestUseCase(repository);
+const registerForContestUseCase = new RegisterForContestUseCase(
+  repository,
+  prisma
+);
+const getContestStatsUseCase = new GetContestStatsUseCase(repository);
+
+const controller = new ContestsController(
+  getContestsUseCase,
+  getContestByIdUseCase,
+  createContestUseCase,
+  registerForContestUseCase,
+  getContestStatsUseCase
+);
+
+const router = Router();
+
+router.get('/stats', (req, res) => controller.getContestStats(req, res));
+router.get('/:id', (req, res) => controller.getContestById(req, res));
+router.get('/', (req, res) => controller.getContests(req, res));
+router.post('/:id/register', (req, res) =>
+  controller.registerForContest(req, res)
+);
+router.post('/', (req, res) => controller.createContest(req, res));
+
+export { router as contestRoutes };

--- a/src/contests/infrastructure/contests.router.ts
+++ b/src/contests/infrastructure/contests.router.ts
@@ -6,9 +6,7 @@ import { CreateContestUseCase } from '../application/use-cases/create-contest.us
 import { RegisterForContestUseCase } from '../application/use-cases/register-for-contest.use-case';
 import { GetContestStatsUseCase } from '../application/use-cases/get-contest-stats.use-case';
 import { PrismaContestRepository } from './persistence/prisma-contest.repository';
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import { prisma } from '../../share/infrastructure/prisma-client';
 const repository = new PrismaContestRepository(prisma);
 
 const getContestsUseCase = new GetContestsUseCase(repository);

--- a/src/contests/infrastructure/contests.router.ts
+++ b/src/contests/infrastructure/contests.router.ts
@@ -6,6 +6,7 @@ import { CreateContestUseCase } from '../application/use-cases/create-contest.us
 import { RegisterForContestUseCase } from '../application/use-cases/register-for-contest.use-case';
 import { GetContestStatsUseCase } from '../application/use-cases/get-contest-stats.use-case';
 import { PrismaContestRepository } from './persistence/prisma-contest.repository';
+import { AuthMiddleware } from '../../auth/infrastructure/middleware/auth-middleware';
 import { prisma } from '../../share/infrastructure/prisma-client';
 const repository = new PrismaContestRepository(prisma);
 
@@ -31,9 +32,11 @@ const router = Router();
 router.get('/stats', (req, res) => controller.getContestStats(req, res));
 router.get('/:id', (req, res) => controller.getContestById(req, res));
 router.get('/', (req, res) => controller.getContests(req, res));
-router.post('/:id/register', (req, res) =>
+router.post('/:id/register', AuthMiddleware.validateToken, (req, res) =>
   controller.registerForContest(req, res)
 );
-router.post('/', (req, res) => controller.createContest(req, res));
+router.post('/', AuthMiddleware.validateToken, (req, res) =>
+  controller.createContest(req, res)
+);
 
 export { router as contestRoutes };

--- a/src/contests/infrastructure/controllers/contests.controller.ts
+++ b/src/contests/infrastructure/controllers/contests.controller.ts
@@ -1,0 +1,193 @@
+import { Request, Response } from 'express';
+import { GetContestsUseCase } from '../../application/use-cases/get-contests.use-case';
+import { GetContestByIdUseCase } from '../../application/use-cases/get-contest-by-id.use-case';
+import { CreateContestUseCase } from '../../application/use-cases/create-contest.use-case';
+import { RegisterForContestUseCase } from '../../application/use-cases/register-for-contest.use-case';
+import { GetContestStatsUseCase } from '../../application/use-cases/get-contest-stats.use-case';
+import { ContestResponseDTO } from '../../application/dtos/contest-response.dto';
+import { Contest, ContestProblem } from '../../domain/entities/contest.entity';
+
+interface AuthenticatedRequest extends Request {
+  user?: { id: string };
+  userId?: string;
+}
+
+export class ContestsController {
+  constructor(
+    private getContestsUseCase: GetContestsUseCase,
+    private getContestByIdUseCase: GetContestByIdUseCase,
+    private createContestUseCase: CreateContestUseCase,
+    private registerForContestUseCase: RegisterForContestUseCase,
+    private getContestStatsUseCase: GetContestStatsUseCase
+  ) {}
+
+  async getContests(req: Request, res: Response): Promise<void> {
+    try {
+      const { status, skip = 0, take = 10 } = req.query;
+      const validStatus = ['upcoming', 'active', 'past'] as const;
+      const statusValue =
+        typeof status === 'string' &&
+        (validStatus as readonly string[]).includes(status)
+          ? (status as (typeof validStatus)[number])
+          : undefined;
+
+      const contests = await this.getContestsUseCase.execute({
+        status: statusValue,
+        skip: Number(skip),
+        take: Number(take),
+      });
+
+      const dto = contests.map(c => this.mapToResponseDTO(c));
+      res.status(200).json({
+        success: true,
+        data: dto,
+      });
+    } catch (error) {
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Internal server error',
+      });
+    }
+  }
+
+  async getContestStats(req: Request, res: Response): Promise<void> {
+    try {
+      const stats = await this.getContestStatsUseCase.execute();
+      res.status(200).json({
+        success: true,
+        data: stats,
+      });
+    } catch (error) {
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Internal server error',
+      });
+    }
+  }
+
+  async getContestById(req: Request, res: Response): Promise<void> {
+    try {
+      const { id } = req.params;
+      const contest = await this.getContestByIdUseCase.execute(id as string);
+
+      if (!contest) {
+        res.status(404).json({
+          success: false,
+          error: 'Contest not found',
+        });
+        return;
+      }
+
+      const dto = this.mapToResponseDTO(contest);
+      res.status(200).json({
+        success: true,
+        data: dto,
+      });
+    } catch (error) {
+      res.status(400).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Bad request',
+      });
+    }
+  }
+
+  async createContest(req: Request, res: Response): Promise<void> {
+    try {
+      const {
+        title,
+        description,
+        difficulty,
+        startTime,
+        endTime,
+        durationMins,
+        prize,
+      } = req.body;
+
+      const contest = await this.createContestUseCase.execute({
+        title,
+        description,
+        difficulty,
+        startTime,
+        endTime,
+        durationMins,
+        prize,
+      });
+
+      const dto = this.mapToResponseDTO(contest);
+      res.status(201).json({
+        success: true,
+        data: dto,
+      });
+    } catch (error) {
+      res.status(400).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Bad request',
+      });
+    }
+  }
+
+  async registerForContest(req: Request, res: Response): Promise<void> {
+    try {
+      const { id } = req.params;
+      const { user, userId } = req as AuthenticatedRequest;
+      const currentUserId = user?.id || userId;
+
+      if (!currentUserId) {
+        res.status(401).json({
+          success: false,
+          error: 'Authentication required',
+        });
+        return;
+      }
+
+      const result = await this.registerForContestUseCase.execute(
+        id as string,
+        currentUserId
+      );
+
+      res.status(200).json({
+        success: true,
+        data: result,
+      });
+    } catch (error) {
+      const errorMsg =
+        error instanceof Error ? error.message : 'Internal server error';
+
+      if (errorMsg === 'Contest not found') {
+        res.status(404).json({
+          success: false,
+          error: errorMsg,
+        });
+        return;
+      }
+
+      res.status(500).json({
+        success: false,
+        error: errorMsg,
+      });
+    }
+  }
+
+  private mapToResponseDTO(contest: Contest): ContestResponseDTO {
+    return {
+      id: contest.getId(),
+      title: contest.getTitle(),
+      description: contest.getDescription(),
+      difficulty: contest.getDifficulty(),
+      status: contest.getStatus().getValue(),
+      startTime: contest.getStartTime().toISOString(),
+      endTime: contest.getEndTime().toISOString(),
+      durationMins: contest.getDurationMins(),
+      prize: contest.getPrize(),
+      isActive: contest.isActiveContest(),
+      createdAt: contest.getCreatedAt().toISOString(),
+      updatedAt: contest.getUpdatedAt().toISOString(),
+      problems: contest.getProblems().map((p: ContestProblem) => ({
+        id: p.id,
+        problemId: p.problemId,
+        order: p.order,
+        points: p.points,
+      })),
+    };
+  }
+}

--- a/src/contests/infrastructure/controllers/contests.controller.ts
+++ b/src/contests/infrastructure/controllers/contests.controller.ts
@@ -84,9 +84,25 @@ export class ContestsController {
         data: dto,
       });
     } catch (error) {
-      res.status(400).json({
+      if (error instanceof Error && error.name === 'ContestValidationError') {
+        res.status(400).json({
+          success: false,
+          error: error.message,
+        });
+        return;
+      }
+
+      if (error instanceof Error && error.name === 'ContestNotFoundError') {
+        res.status(404).json({
+          success: false,
+          error: error.message,
+        });
+        return;
+      }
+
+      res.status(500).json({
         success: false,
-        error: error instanceof Error ? error.message : 'Bad request',
+        error: error instanceof Error ? error.message : 'Internal server error',
       });
     }
   }
@@ -121,9 +137,25 @@ export class ContestsController {
         data: dto,
       });
     } catch (error) {
-      res.status(400).json({
+      if (error instanceof Error && error.name === 'ContestValidationError') {
+        res.status(400).json({
+          success: false,
+          error: error.message,
+        });
+        return;
+      }
+
+      if (error instanceof Error && error.name === 'ContestNotFoundError') {
+        res.status(404).json({
+          success: false,
+          error: error.message,
+        });
+        return;
+      }
+
+      res.status(500).json({
         success: false,
-        error: error instanceof Error ? error.message : 'Bad request',
+        error: error instanceof Error ? error.message : 'Internal server error',
       });
     }
   }
@@ -152,20 +184,17 @@ export class ContestsController {
         data: result,
       });
     } catch (error) {
-      const errorMsg =
-        error instanceof Error ? error.message : 'Internal server error';
-
-      if (errorMsg === 'Contest not found') {
+      if (error instanceof Error && error.name === 'ContestNotFoundError') {
         res.status(404).json({
           success: false,
-          error: errorMsg,
+          error: error.message,
         });
         return;
       }
 
       res.status(500).json({
         success: false,
-        error: errorMsg,
+        error: error instanceof Error ? error.message : 'Internal server error',
       });
     }
   }

--- a/src/contests/infrastructure/controllers/contests.controller.ts
+++ b/src/contests/infrastructure/controllers/contests.controller.ts
@@ -101,6 +101,7 @@ export class ContestsController {
         endTime,
         durationMins,
         prize,
+        problemIds,
       } = req.body;
 
       const contest = await this.createContestUseCase.execute({
@@ -111,6 +112,7 @@ export class ContestsController {
         endTime,
         durationMins,
         prize,
+        problemIds,
       });
 
       const dto = this.mapToResponseDTO(contest);
@@ -187,6 +189,12 @@ export class ContestsController {
         problemId: p.problemId,
         order: p.order,
         points: p.points,
+        problem: p.problem && {
+          id: p.problem.id,
+          title: p.problem.title,
+          description: p.problem.description,
+          difficulty: p.problem.difficulty,
+        },
       })),
     };
   }

--- a/src/contests/infrastructure/persistence/prisma-contest.repository.ts
+++ b/src/contests/infrastructure/persistence/prisma-contest.repository.ts
@@ -3,7 +3,7 @@ import {
   Prisma,
   Contest as PrismaContest,
   ContestProblem as PrismaContestProblem,
-  Problem as PrismaProblem,
+  ContestProblemDef as PrismaProblem,
 } from '@prisma/client';
 import {
   Contest,

--- a/src/contests/infrastructure/persistence/prisma-contest.repository.ts
+++ b/src/contests/infrastructure/persistence/prisma-contest.repository.ts
@@ -60,7 +60,7 @@ export class PrismaContestRepository implements ContestRepository {
     return this.mapToDomain(contest);
   }
 
-  async create(contest: Contest): Promise<Contest> {
+  async create(contest: Contest, problemIds?: string[]): Promise<Contest> {
     const created = await this.prisma.contest.create({
       data: {
         title: contest.getTitle(),
@@ -72,6 +72,16 @@ export class PrismaContestRepository implements ContestRepository {
         endTime: contest.getEndTime(),
         durationMins: contest.getDurationMins(),
         isActive: contest.isActiveContest(),
+        problems:
+          problemIds && problemIds.length
+            ? {
+                create: problemIds.map(problemId => ({
+                  problem: {
+                    connect: { id: problemId },
+                  },
+                })),
+              }
+            : undefined,
       },
       include: {
         problems: {
@@ -121,6 +131,14 @@ export class PrismaContestRepository implements ContestRepository {
       problemId: p.problemId,
       order: p.order,
       points: p.points,
+      problem: p.problem
+        ? {
+            id: p.problem.id,
+            title: p.problem.title,
+            description: p.problem.description,
+            difficulty: p.problem.difficulty,
+          }
+        : undefined,
     }));
 
     return Contest.create(

--- a/src/contests/infrastructure/persistence/prisma-contest.repository.ts
+++ b/src/contests/infrastructure/persistence/prisma-contest.repository.ts
@@ -1,0 +1,142 @@
+import {
+  PrismaClient,
+  Prisma,
+  Contest as PrismaContest,
+  ContestProblem as PrismaContestProblem,
+  Problem as PrismaProblem,
+} from '@prisma/client';
+import {
+  Contest,
+  ContestProblem as ContestProblemEntity,
+} from '../../domain/entities/contest.entity';
+import {
+  ContestRepository,
+  GetContestsParams,
+  ContestStats,
+} from '../../domain/repositories/contest.repository';
+
+type RawContest = PrismaContest & {
+  problems: Array<PrismaContestProblem & { problem: PrismaProblem }>;
+};
+
+export class PrismaContestRepository implements ContestRepository {
+  constructor(private prisma: PrismaClient) {}
+
+  async getAll(params: GetContestsParams): Promise<Contest[]> {
+    const where: Prisma.ContestWhereInput = {};
+    if (params.status) {
+      where.status = params.status;
+    }
+
+    const contests = await this.prisma.contest.findMany({
+      where,
+      include: {
+        problems: {
+          include: {
+            problem: true,
+          },
+        },
+      },
+      skip: params.skip || 0,
+      take: params.take || 10,
+    });
+
+    return contests.map(c => this.mapToDomain(c));
+  }
+
+  async getById(id: string): Promise<Contest | null> {
+    const contest = await this.prisma.contest.findUnique({
+      where: { id },
+      include: {
+        problems: {
+          include: {
+            problem: true,
+          },
+        },
+      },
+    });
+
+    if (!contest) return null;
+    return this.mapToDomain(contest);
+  }
+
+  async create(contest: Contest): Promise<Contest> {
+    const created = await this.prisma.contest.create({
+      data: {
+        title: contest.getTitle(),
+        description: contest.getDescription(),
+        difficulty: contest.getDifficulty(),
+        status: contest.getStatus().getValue(),
+        prize: contest.getPrize(),
+        startTime: contest.getStartTime(),
+        endTime: contest.getEndTime(),
+        durationMins: contest.getDurationMins(),
+        isActive: contest.isActiveContest(),
+      },
+      include: {
+        problems: {
+          include: {
+            problem: true,
+          },
+        },
+      },
+    });
+
+    return this.mapToDomain(created);
+  }
+
+  async getStats(): Promise<ContestStats> {
+    const [live, upcoming, past, totalRegistrations] = await Promise.all([
+      this.prisma.contest.count({
+        where: {
+          status: 'active',
+          isActive: true,
+        },
+      }),
+      this.prisma.contest.count({
+        where: {
+          status: 'upcoming',
+          isActive: true,
+        },
+      }),
+      this.prisma.contest.count({
+        where: {
+          status: 'past',
+        },
+      }),
+      this.prisma.contestRegistration.count(),
+    ]);
+
+    return {
+      live,
+      upcoming,
+      past,
+      totalRegistrations,
+    };
+  }
+
+  private mapToDomain(raw: RawContest): Contest {
+    const problems: ContestProblemEntity[] = (raw.problems || []).map(p => ({
+      id: p.id,
+      problemId: p.problemId,
+      order: p.order,
+      points: p.points,
+    }));
+
+    return Contest.create(
+      raw.id,
+      raw.title,
+      raw.description,
+      raw.difficulty,
+      raw.status,
+      raw.startTime,
+      raw.endTime,
+      raw.durationMins,
+      raw.isActive,
+      raw.prize,
+      raw.createdAt,
+      raw.updatedAt,
+      problems
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { authRoutes } from './auth/infrastructure/routes/auth-routes';
 import { userRoutes } from './user/infrastructure/routes/user-routes';
 import { testRoutes } from './tests/infraestructure/routes/test-routes';
 import { courseRoutes } from './course/infrastructure/routes/course-routes';
+import { contestRoutes } from './contests/infrastructure/contests.router';
 
 const app: Application = express();
 
@@ -41,6 +42,7 @@ app.use('/api/auth', authRoutes);
 app.use('/api/user', AuthMiddleware.validateToken, userRoutes);
 app.use('/api/tests', testRoutes);
 app.use('/api/courses', courseRoutes);
+app.use('/api/contests', contestRoutes);
 
 app.use('*', (req: Request, res: Response) => {
   res.status(404).json({


### PR DESCRIPTION
## Summary

This PR adds the `contests` module and connects it to the existing backend.

### Files added/updated

- `src/contests/domain/entities/contest.entity.ts`
- `src/contests/domain/value-objects/contest-status.vo.ts`
- `src/contests/domain/repositories/contest.repository.ts`
- `src/contests/application/dtos/*`
- `src/contests/application/use-cases/*`
- `src/contests/infrastructure/persistence/prisma-contest.repository.ts`
- `src/contests/infrastructure/controllers/contests.controller.ts`
- `src/contests/infrastructure/contests.router.ts`
- `src/index.ts`
- `prisma/schema.prisma`

### What works

- `yarn build` succeeds
- `GET /api/contests`
- `GET /api/contests/stats`
- `POST /api/contests`
- `GET /api/contests/:id`
- `GET /api/contests?status=upcoming`
- `GET /api/contests?status=active`
- `GET /api/contests?status=past`

### Notes

- Contest registration endpoint is implemented and requires authentication.
- `POST /api/contests/:id/register` returns `401` without a JWT.Tests performed
yarn build

Verified TypeScript compile success with tsc && tsc-alias
Started backend and confirmed server runs on port 3000

API endpoint checks:

GET /api/contests
returned 200
returned contest list
GET /api/contests/stats
returned 200
returned valid counts
POST /api/contests
returned 201
created contest successfully
GET /api/contests/:id
returned 200
retrieved created contest
GET /api/contests?status=upcoming
returned 200
returned only upcoming contests
GET /api/contests?status=active
returned 200
returned empty list when none active
GET /api/contests?status=past
returned 200
returned empty list when none past
POST /api/contests/:id/register

returned 401 Authentication required
confirmed auth is required for registration