### PR TITLE
feat: add Prisma models Problem, TestCase, StarterCode, ProblemSubmis…

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prepare": "npx husky install",
     "test": "echo \"Error: no test specified\" && exit 1",
     "db:up": "docker compose -f ./local-database/database.yaml up -d",
-    "prisma:migrate": "npx prisma migrate dev --name init"
+    "prisma:migrate": "npx prisma migrate dev"
   },
   "keywords": [
     "express",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-leetcode",
-  "version": "0.0.3-rc.0",
+  "version": "0.0.2",
   "description": "Express API with TypeScript",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-leetcode",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Express API with TypeScript",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-leetcode",
-  "version": "0.0.2",
+  "version": "0.0.3-rc.0",
   "description": "Express API with TypeScript",
   "main": "dist/index.js",
   "scripts": {

--- a/prisma/migrations/20260515194430_add_problems_submissions/migration.sql
+++ b/prisma/migrations/20260515194430_add_problems_submissions/migration.sql
@@ -1,27 +1,4 @@
 -- CreateTable
-CREATE TABLE "courses" (
-    "id" TEXT NOT NULL,
-    "title" TEXT NOT NULL,
-    "description" TEXT NOT NULL,
-    "number_of_lessons" INTEGER NOT NULL,
-    "is_active" BOOLEAN NOT NULL DEFAULT true,
-    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updated_at" TIMESTAMP(3) NOT NULL,
-
-    CONSTRAINT "courses_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
-CREATE TABLE "enrollments" (
-    "id" TEXT NOT NULL,
-    "user_id" TEXT NOT NULL,
-    "course_id" TEXT NOT NULL,
-    "enrolled_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-
-    CONSTRAINT "enrollments_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
 CREATE TABLE "problems" (
     "id" TEXT NOT NULL,
     "slug" TEXT NOT NULL,
@@ -92,18 +69,6 @@ CREATE TABLE "execution_results" (
 );
 
 -- CreateIndex
-CREATE INDEX "courses_is_active_idx" ON "courses"("is_active");
-
--- CreateIndex
-CREATE INDEX "enrollments_user_id_idx" ON "enrollments"("user_id");
-
--- CreateIndex
-CREATE INDEX "enrollments_course_id_idx" ON "enrollments"("course_id");
-
--- CreateIndex
-CREATE UNIQUE INDEX "enrollments_user_id_course_id_key" ON "enrollments"("user_id", "course_id");
-
--- CreateIndex
 CREATE UNIQUE INDEX "problems_slug_key" ON "problems"("slug");
 
 -- CreateIndex
@@ -138,12 +103,6 @@ CREATE INDEX "problem_submissions_language_idx" ON "problem_submissions"("langua
 
 -- CreateIndex
 CREATE UNIQUE INDEX "execution_results_problem_submission_id_key" ON "execution_results"("problem_submission_id");
-
--- AddForeignKey
-ALTER TABLE "enrollments" ADD CONSTRAINT "enrollments_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "enrollments" ADD CONSTRAINT "enrollments_course_id_fkey" FOREIGN KEY ("course_id") REFERENCES "courses"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "test_cases" ADD CONSTRAINT "test_cases_problem_id_fkey" FOREIGN KEY ("problem_id") REFERENCES "problems"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260515194430_add_problems_submissions/migration.sql
+++ b/prisma/migrations/20260515194430_add_problems_submissions/migration.sql
@@ -1,0 +1,161 @@
+-- CreateTable
+CREATE TABLE "courses" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "number_of_lessons" INTEGER NOT NULL,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "courses_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "enrollments" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "course_id" TEXT NOT NULL,
+    "enrolled_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "enrollments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "problems" (
+    "id" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "difficulty" TEXT NOT NULL,
+    "tags" TEXT[],
+    "constraints" TEXT[],
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "accepted_count" INTEGER NOT NULL DEFAULT 0,
+    "submission_count" INTEGER NOT NULL DEFAULT 0,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "problems_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "test_cases" (
+    "id" TEXT NOT NULL,
+    "problem_id" TEXT NOT NULL,
+    "input" TEXT NOT NULL,
+    "expected_output" TEXT NOT NULL,
+    "explanation" TEXT,
+    "is_example" BOOLEAN NOT NULL DEFAULT false,
+    "order" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "test_cases_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "starter_codes" (
+    "id" TEXT NOT NULL,
+    "problem_id" TEXT NOT NULL,
+    "language" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+
+    CONSTRAINT "starter_codes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "problem_submissions" (
+    "id" TEXT NOT NULL,
+    "problem_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "language" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "mode" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "runtime_ms" INTEGER,
+    "memory_mb" DOUBLE PRECISION,
+    "score" DOUBLE PRECISION,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "problem_submissions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "execution_results" (
+    "id" TEXT NOT NULL,
+    "problem_submission_id" TEXT NOT NULL,
+    "compile_error" TEXT,
+    "test_case_results" JSONB NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "execution_results_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "courses_is_active_idx" ON "courses"("is_active");
+
+-- CreateIndex
+CREATE INDEX "enrollments_user_id_idx" ON "enrollments"("user_id");
+
+-- CreateIndex
+CREATE INDEX "enrollments_course_id_idx" ON "enrollments"("course_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "enrollments_user_id_course_id_key" ON "enrollments"("user_id", "course_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "problems_slug_key" ON "problems"("slug");
+
+-- CreateIndex
+CREATE INDEX "problems_difficulty_idx" ON "problems"("difficulty");
+
+-- CreateIndex
+CREATE INDEX "problems_is_active_idx" ON "problems"("is_active");
+
+-- CreateIndex
+CREATE INDEX "problems_slug_idx" ON "problems"("slug");
+
+-- CreateIndex
+CREATE INDEX "test_cases_problem_id_idx" ON "test_cases"("problem_id");
+
+-- CreateIndex
+CREATE INDEX "test_cases_is_example_idx" ON "test_cases"("is_example");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "starter_codes_problem_id_language_key" ON "starter_codes"("problem_id", "language");
+
+-- CreateIndex
+CREATE INDEX "problem_submissions_problem_id_idx" ON "problem_submissions"("problem_id");
+
+-- CreateIndex
+CREATE INDEX "problem_submissions_user_id_idx" ON "problem_submissions"("user_id");
+
+-- CreateIndex
+CREATE INDEX "problem_submissions_status_idx" ON "problem_submissions"("status");
+
+-- CreateIndex
+CREATE INDEX "problem_submissions_language_idx" ON "problem_submissions"("language");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "execution_results_problem_submission_id_key" ON "execution_results"("problem_submission_id");
+
+-- AddForeignKey
+ALTER TABLE "enrollments" ADD CONSTRAINT "enrollments_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "enrollments" ADD CONSTRAINT "enrollments_course_id_fkey" FOREIGN KEY ("course_id") REFERENCES "courses"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "test_cases" ADD CONSTRAINT "test_cases_problem_id_fkey" FOREIGN KEY ("problem_id") REFERENCES "problems"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "starter_codes" ADD CONSTRAINT "starter_codes_problem_id_fkey" FOREIGN KEY ("problem_id") REFERENCES "problems"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "problem_submissions" ADD CONSTRAINT "problem_submissions_problem_id_fkey" FOREIGN KEY ("problem_id") REFERENCES "problems"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "problem_submissions" ADD CONSTRAINT "problem_submissions_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "execution_results" ADD CONSTRAINT "execution_results_problem_submission_id_fkey" FOREIGN KEY ("problem_submission_id") REFERENCES "problem_submissions"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,11 +20,12 @@ model User {
   password  String
   createdAt DateTime @default(now()) @map("created_at")
 
-  // Relaciones
-  testSessions TestSession[]
-  submissions  Submission[]
-  refreshTokens RefreshToken[]
-  enrollments  Enrollment[]
+  // Relations
+  testSessions       TestSession[]
+  submissions        Submission[]
+  refreshTokens      RefreshToken[]
+  enrollments        Enrollment[]
+  problemSubmissions ProblemSubmission[]
 
   @@map("users")
 }
@@ -39,10 +40,10 @@ model RefreshToken {
   expiresAt DateTime @map("expires_at")
   createdAt DateTime @default(now()) @map("created_at")
   isRevoked Boolean  @default(false) @map("is_revoked")
-  
-  // Relaciones
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  
+
+  // Relations
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
   @@index([userId])
   @@index([token])
   @@index([expiresAt])
@@ -50,7 +51,7 @@ model RefreshToken {
 }
 
 // ============================================
-// NUEVOS MODELOS - Companies
+// MODELO - Company
 // ============================================
 model Company {
   id        String   @id @default(uuid())
@@ -58,27 +59,27 @@ model Company {
   logo      String?
   createdAt DateTime @default(now()) @map("created_at")
 
-  // Relaciones
+  // Relations
   tests Test[]
 
   @@map("companies")
 }
 
 // ============================================
-// NUEVOS MODELOS - Tests
+// MODELO - Test
 // ============================================
 model Test {
   id          String   @id @default(uuid())
   name        String
   description String
   companyId   String?  @map("company_id")
-  difficulty  String // 'EASY', 'MEDIUM', 'HARD'
-  duration    Int // minutos
+  difficulty  String   // 'EASY', 'MEDIUM', 'HARD'
+  duration    Int      // minutes
   isActive    Boolean  @default(true) @map("is_active")
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @updatedAt @map("updated_at")
 
-  // Relaciones con Foreign Keys
+  // Relations
   company      Company?      @relation(fields: [companyId], references: [id], onDelete: SetNull)
   questions    Question[]
   testSessions TestSession[]
@@ -91,7 +92,7 @@ model Test {
 }
 
 // ============================================
-// NUEVOS MODELOS - Questions
+// MODELO - Question
 // ============================================
 model Question {
   id         String @id @default(uuid())
@@ -100,21 +101,21 @@ model Question {
   text       String @db.Text
   difficulty String // 'EASY', 'MEDIUM', 'HARD'
   points     Int    @default(1)
-  timeLimit  Int?   @map("time_limit") // segundos, opcional
+  timeLimit  Int?   @map("time_limit") // seconds, optional
   order      Int    @default(0)
 
-  // Para MCQ - almacenado como JSON
-  options       Json? // [{ id: "A", text: "Opción A" }, ...]
-  correctAnswer Json? @map("correct_answer") // ["A", "C"] para respuestas correctas
+  // For MCQ — stored as JSON
+  options       Json? // [{ id: "A", text: "Option A" }, ...]
+  correctAnswer Json? @map("correct_answer") // ["A", "C"] for correct answers
 
-  // Para Programming - almacenado como JSON
+  // For Programming — stored as JSON
   programmingData Json? @map("programming_data")
   // { starterCode: "...", testCases: [...], expectedOutput: "..." }
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  // Relaciones con Foreign Keys
+  // Relations
   test    Test     @relation(fields: [testId], references: [id], onDelete: Cascade)
   answers Answer[]
 
@@ -125,7 +126,7 @@ model Question {
 }
 
 // ============================================
-// NUEVOS MODELOS - Test Sessions
+// MODELO - TestSession
 // ============================================
 model TestSession {
   id        String   @id @default(uuid())
@@ -135,7 +136,7 @@ model TestSession {
   expiresAt DateTime @map("expires_at")
   isActive  Boolean  @default(true) @map("is_active")
 
-  // Relaciones con Foreign Keys
+  // Relations
   test       Test        @relation(fields: [testId], references: [id], onDelete: Cascade)
   user       User        @relation(fields: [userId], references: [id], onDelete: Cascade)
   answers    Answer[]
@@ -149,17 +150,17 @@ model TestSession {
 }
 
 // ============================================
-// NUEVOS MODELOS - Answers
+// MODELO - Answer
 // ============================================
 model Answer {
   id         String @id @default(uuid())
   sessionId  String @map("session_id")
   questionId String @map("question_id")
 
-  // Para MCQ
+  // For MCQ
   selectedOption String? @map("selected_option") // "A", "B", "C", etc.
 
-  // Para Programming
+  // For Programming
   code     String? @db.Text
   language String?
 
@@ -167,7 +168,7 @@ model Answer {
   points     Int?
   answeredAt DateTime @default(now()) @map("answered_at")
 
-  // Relaciones con Foreign Keys
+  // Relations
   session  TestSession @relation(fields: [sessionId], references: [id], onDelete: Cascade)
   question Question    @relation(fields: [questionId], references: [id], onDelete: Cascade)
 
@@ -178,7 +179,7 @@ model Answer {
 }
 
 // ============================================
-// NUEVOS MODELOS - Submissions
+// MODELO - Submission
 // ============================================
 model Submission {
   id          String   @id @default(uuid())
@@ -187,10 +188,10 @@ model Submission {
   userId      String   @map("user_id")
   score       Float
   maxScore    Float    @map("max_score")
-  breakdown   Json // { correct: 10, incorrect: 2, total: 12 }
+  breakdown   Json     // { correct: 10, incorrect: 2, total: 12 }
   submittedAt DateTime @default(now()) @map("submitted_at")
 
-  // Relaciones con Foreign Keys
+  // Relations
   test    Test        @relation(fields: [testId], references: [id], onDelete: Cascade)
   session TestSession @relation(fields: [sessionId], references: [id], onDelete: Cascade)
   user    User        @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -201,6 +202,9 @@ model Submission {
   @@map("submissions")
 }
 
+// ============================================
+// MODELO - Course
+// ============================================
 model Course {
   id              String   @id @default(uuid())
   title           String
@@ -216,6 +220,9 @@ model Course {
   @@map("courses")
 }
 
+// ============================================
+// MODELO - Enrollment
+// ============================================
 model Enrollment {
   id         String   @id @default(uuid())
   userId     String   @map("user_id")
@@ -229,4 +236,109 @@ model Enrollment {
   @@index([userId])
   @@index([courseId])
   @@map("enrollments")
+}
+
+// ============================================
+// Problem — a LeetCode-style coding problem
+// ============================================
+model Problem {
+  id              String   @id @default(uuid())
+  slug            String   @unique            // e.g. "two-sum"
+  title           String
+  description     String   @db.Text
+  difficulty      String                      // 'EASY' | 'MEDIUM' | 'HARD'
+  tags            String[]                    // e.g. ["Array", "Hash Table"]
+  constraints     String[] @db.Text           // list of constraint strings
+  isActive        Boolean  @default(true)     @map("is_active")
+  acceptedCount   Int      @default(0)        @map("accepted_count")
+  submissionCount Int      @default(0)        @map("submission_count")
+  createdAt       DateTime @default(now())    @map("created_at")
+  updatedAt       DateTime @updatedAt         @map("updated_at")
+
+  testCases          TestCase[]
+  starterCodes       StarterCode[]
+  problemSubmissions ProblemSubmission[]
+
+  @@index([difficulty])
+  @@index([isActive])
+  @@index([slug])
+  @@map("problems")
+}
+
+// ============================================
+// TestCase — input/output pairs for a problem
+// ============================================
+model TestCase {
+  id             String  @id @default(uuid())
+  problemId      String  @map("problem_id")
+  input          String  @db.Text
+  expectedOutput String  @db.Text             @map("expected_output")
+  explanation    String? @db.Text
+  isExample      Boolean @default(false)      @map("is_example") // shown in problem description
+  order          Int     @default(0)
+
+  problem Problem @relation(fields: [problemId], references: [id], onDelete: Cascade)
+
+  @@index([problemId])
+  @@index([isExample])
+  @@map("test_cases")
+}
+
+// ============================================
+// StarterCode — per-language boilerplate
+// ============================================
+model StarterCode {
+  id        String @id @default(uuid())
+  problemId String @map("problem_id")
+  language  String // 'java' | 'typescript' | 'cpp'
+  code      String @db.Text
+
+  problem Problem @relation(fields: [problemId], references: [id], onDelete: Cascade)
+
+  @@unique([problemId, language])
+  @@map("starter_codes")
+}
+
+// ============================================
+// ProblemSubmission — one run or submit attempt
+// ============================================
+model ProblemSubmission {
+  id        String   @id @default(uuid())
+  problemId String   @map("problem_id")
+  userId    String   @map("user_id")
+  language  String                          // 'java' | 'typescript' | 'cpp'
+  code      String   @db.Text
+  mode      String                          // 'run' | 'submit'
+  status    String   @default("pending")    // 'pending' | 'running' | 'accepted' | 'wrong_answer' | 'time_limit_exceeded' | 'runtime_error' | 'compile_error'
+  runtimeMs Int?     @map("runtime_ms")
+  memoryMb  Float?   @map("memory_mb")
+  score     Float?                          // percentage of test cases passed (0–100)
+  createdAt DateTime @default(now())        @map("created_at")
+  updatedAt DateTime @updatedAt             @map("updated_at")
+
+  problem         Problem          @relation(fields: [problemId], references: [id], onDelete: Cascade)
+  user            User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  executionResult ExecutionResult?
+
+  @@index([problemId])
+  @@index([userId])
+  @@index([status])
+  @@index([language])
+  @@map("problem_submissions")
+}
+
+// ============================================
+// ExecutionResult — detailed per-test-case results
+// ============================================
+model ExecutionResult {
+  id                  String   @id @default(uuid())
+  problemSubmissionId String   @unique               @map("problem_submission_id")
+  compileError        String?  @db.Text              @map("compile_error")
+  testCaseResults     Json                           @map("test_case_results")
+  // JSON shape: Array<{ testCaseId, passed, input, expectedOutput, actualOutput, runtimeMs }>
+  createdAt           DateTime @default(now())       @map("created_at")
+
+  problemSubmission ProblemSubmission @relation(fields: [problemSubmissionId], references: [id], onDelete: Cascade)
+
+  @@map("execution_results")
 }


### PR DESCRIPTION
Extends the Prisma schema with the models needed for the coding problems domain.

Changes:
- Added Problem model with slug, difficulty, tags, constraints, and pagination-friendly indexes
- Added TestCase model with input/output pairs and isExample flag
- Added StarterCode model with unique constraint per language per problem
- Added ProblemSubmission model with string-based status (no enum)
- Added ExecutionResult model with JSON test case results
- Updated User model with problemSubmissions relation
- Updated prisma:migrate script to accept custom --name flag
- Generated migration: 20260515194430_add_problems_submissions